### PR TITLE
[FEAT] 네이버 검색 API 설정 추가

### DIFF
--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -14,3 +14,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update      # 추후 validate
+
+api:
+  naver:
+    map:
+      client-id: ${CLIENT_ID}
+      client-secret: ${CLIENT_SECRET}

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -28,3 +28,11 @@ management:
   health:
     defaults:
       enabled: true
+
+api:
+  naver:
+    map:
+      client-id: ${CLIENT_ID}
+      client-secret: ${CLIENT_SECRET}
+      geocoding-base-url: https://naveropenapi.apigw.ntruss.com/map-geocode/v2
+      local-search-base-url: https://openapi.naver.com/v1/search

--- a/module-domain/build.gradle.kts
+++ b/module-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     implementation(project(":module-global-utils"))
 
+    implementation("org.springframework.boot:spring-boot-starter")
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     implementation("org.hibernate.orm:hibernate-core")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")

--- a/module-infra/build.gradle.kts
+++ b/module-infra/build.gradle.kts
@@ -3,10 +3,26 @@ dependencies {
     implementation(project(":module-domain"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.5")
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.5")
     implementation("com.linecorp.kotlin-jdsl:hibernate-support:3.5.5")
     implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:3.5.5")
+    
+    // HTTP Client
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
+    implementation("org.apache.httpcomponents.core5:httpcore5:5.2.4")
+    
+    // Kotlin Logging
+    implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
+    
+    // Test Dependencies
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.mockito:mockito-core")
+    testImplementation("org.mockito:mockito-junit-jupiter")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 }
 
 tasks {

--- a/module-infra/src/main/kotlin/org/depromeet/team3/common/NaverApiProperties.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/common/NaverApiProperties.kt
@@ -1,0 +1,11 @@
+package org.depromeet.team3.common
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "api.naver.map")
+data class NaverApiProperties(
+    val clientId: String,
+    val clientSecret: String,
+    val geocodingBaseUrl: String,
+    val localSearchBaseUrl: String
+)

--- a/module-infra/src/main/kotlin/org/depromeet/team3/config/NaverMapRestClientConfiguration.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/config/NaverMapRestClientConfiguration.kt
@@ -1,0 +1,89 @@
+package org.depromeet.team3.config
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager
+import org.depromeet.team3.common.NaverApiProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+
+@Configuration
+@EnableConfigurationProperties(NaverApiProperties::class)
+class NaverMapRestClientConfiguration(
+    private val properties: NaverApiProperties
+) {
+
+    private val logger = KotlinLogging.logger { NaverMapRestClientConfiguration::class.java.name }
+
+    companion object {
+        const val MAX_CONNECTION_TOTAL = 3
+        const val MAX_PER_ROUTE = 5
+    }
+
+    @Bean
+    fun naverMapGeocodingRestClient(): RestClient {
+        return RestClient.builder()
+            .requestFactory(httpRequestFactory())
+            .baseUrl(properties.geocodingBaseUrl)
+            .defaultHeaders { headers ->
+                headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                headers.set("X-Naver-Client-Id", properties.clientId)
+                headers.set("X-Naver-Client-Secret", properties.clientSecret)
+            }
+            .defaultStatusHandler(HttpStatusCode::is5xxServerError) { request, response ->
+                logger.error {
+                    "Naver Map Geocoding API request failed. " +
+                        "Status: ${response.statusCode}, " +
+                        "URL: ${request.uri}, " +
+                        "Method: ${request.method}"
+                }
+            }
+            .build()
+    }
+
+    @Bean
+    fun naverMapLocalSearchRestClient(): RestClient {
+        return RestClient.builder()
+            .requestFactory(httpRequestFactory())
+            .baseUrl(properties.localSearchBaseUrl)
+            .defaultHeaders { headers ->
+                headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                headers.set("X-Naver-Client-Id", properties.clientId)
+                headers.set("X-Naver-Client-Secret", properties.clientSecret)
+            }
+            .defaultStatusHandler(HttpStatusCode::is5xxServerError) { request, response ->
+                logger.error {
+                    "Naver Map Local Search API request failed. " +
+                        "Status: ${response.statusCode}, " +
+                        "URL: ${request.uri}, " +
+                        "Method: ${request.method}"
+                }
+            }
+            .build()
+    }
+
+    @Bean
+    fun httpRequestFactory(): ClientHttpRequestFactory {
+        val httpClient = HttpClients.custom()
+            .setConnectionManager(pollConnectionManager())
+            .build()
+
+        return HttpComponentsClientHttpRequestFactory(httpClient)
+    }
+
+    @Bean
+    fun pollConnectionManager(): PoolingHttpClientConnectionManager {
+        val manager = PoolingHttpClientConnectionManager()
+        manager.maxTotal = MAX_CONNECTION_TOTAL
+        manager.defaultMaxPerRoute = MAX_PER_ROUTE
+
+        return manager
+    }
+}

--- a/module-infra/src/test/kotlin/org/depromeet/team3/naver/dto/NaverLocalSearchResponse.kt
+++ b/module-infra/src/test/kotlin/org/depromeet/team3/naver/dto/NaverLocalSearchResponse.kt
@@ -1,0 +1,25 @@
+package org.depromeet.team3.naver.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class NaverLocalSearchResponse(
+    val lastBuildDate: String,
+    val total: Int,
+    val start: Int,
+    val display: Int,
+    val items: List<NaverLocalSearchItem>
+)
+
+data class NaverLocalSearchItem(
+    val title: String,
+    val link: String,
+    val category: String,
+    val description: String,
+    val telephone: String?,
+    val address: String,
+    val roadAddress: String,
+    @JsonProperty("mapx")
+    val mapX: String,
+    @JsonProperty("mapy")
+    val mapY: String
+)

--- a/module-infra/src/test/kotlin/org/depromeet/team3/naver/service/NaverMapServiceTest.kt
+++ b/module-infra/src/test/kotlin/org/depromeet/team3/naver/service/NaverMapServiceTest.kt
@@ -1,0 +1,161 @@
+package org.depromeet.team3.naver.service
+
+import org.depromeet.team3.naver.dto.NaverLocalSearchItem
+import org.depromeet.team3.naver.dto.NaverLocalSearchResponse
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NaverMapServiceTest {
+
+    @Test
+    fun `Mock 테스트`() {
+        // given
+        val mockResponse = createMockResponse()
+
+        // when & then
+        assertNotNull(mockResponse)
+        assertEquals(2, mockResponse.items.size)
+        assertEquals("한식당1", mockResponse.items[0].title)
+        assertEquals("한식", mockResponse.items[0].category)
+        assertEquals("강남구 테헤란로 123", mockResponse.items[0].address)
+        assertEquals("02-1234-5678", mockResponse.items[0].telephone)
+        assertEquals("127.027619", mockResponse.items[0].mapX)
+        assertEquals("37.497952", mockResponse.items[0].mapY)
+        
+        mockResponse.items.forEachIndexed { index, item ->
+            println("${index + 1}. ${item.title}")
+            println("   카테고리: ${item.category}")
+            println("   주소: ${item.address}")
+            println("   도로명주소: ${item.roadAddress}")
+            println("   전화번호: ${item.telephone ?: "정보 없음"}")
+            println("   설명: ${item.description}")
+            println("   좌표: (${item.mapX}, ${item.mapY})")
+            println("   링크: ${item.link}")
+            println()
+        }
+    }
+
+    @Test
+    fun `NaverLocalSearchItem 필드 검증 테스트`() {
+        // given
+        val item = NaverLocalSearchItem(
+            title = "테스트 식당",
+            link = "https://map.naver.com/v5/entry/place/1234567890",
+            category = "한식",
+            description = "테스트용 식당입니다",
+            telephone = "02-1234-5678",
+            address = "서울시 강남구 테스트로 123",
+            roadAddress = "서울특별시 강남구 테스트로 123",
+            mapX = "127.027619",
+            mapY = "37.497952"
+        )
+
+        // when & then
+        assertNotNull(item)
+        assertEquals("테스트 식당", item.title)
+        assertEquals("한식", item.category)
+        assertEquals("서울시 강남구 테스트로 123", item.address)
+        assertEquals("서울특별시 강남구 테스트로 123", item.roadAddress)
+        assertEquals("02-1234-5678", item.telephone)
+        assertEquals("127.027619", item.mapX)
+        assertEquals("37.497952", item.mapY)
+
+        println("식당명: ${item.title}")
+        println("카테고리: ${item.category}")
+        println("주소: ${item.address}")
+        println("도로명주소: ${item.roadAddress}")
+        println("전화번호: ${item.telephone}")
+        println("좌표: (${item.mapX}, ${item.mapY})")
+        println("설명: ${item.description}")
+        println("링크: ${item.link}")
+        println()
+    }
+
+    @Test
+    fun `음식 카테고리별 검색 시나리오 테스트`() {
+        // given
+        val categories = listOf("한식", "중식", "일식", "양식", "카페")
+        
+        println("=== 음식 카테고리별 검색 시나리오 테스트 ===")
+        
+        // when & then
+        categories.forEach { category ->
+            val response = createMockResponseForCategory(category)
+            
+            assertNotNull(response)
+            assertNotNull(response.items)
+            assertTrue(response.items.isNotEmpty(), "$category 카테고리 검색 결과 없음")
+            
+            response.items.forEach { item ->
+                assertNotNull(item.title, "식당 이름 없음")
+                assertNotNull(item.category, "카테고리 없음")
+                assertNotNull(item.address, "주소 없음")
+                assertNotNull(item.mapX, "X 좌표 없음")
+                assertNotNull(item.mapY, "Y 좌표 없음")
+                
+                println("   🍽️  ${item.title}")
+                println("      카테고리: ${item.category}")
+                println("      주소: ${item.address}")
+                println("      전화번호: ${item.telephone ?: "정보 없음"}")
+                println("      좌표: (${item.mapX}, ${item.mapY})")
+            }
+        }
+    }
+
+    private fun createMockResponse(): NaverLocalSearchResponse {
+        return NaverLocalSearchResponse(
+            lastBuildDate = "2024-01-01T00:00:00.000+09:00",
+            total = 2,
+            start = 1,
+            display = 2,
+            items = listOf(
+                NaverLocalSearchItem(
+                    title = "한식당1",
+                    link = "https://map.naver.com/v5/entry/place/1234567890",
+                    category = "한식",
+                    description = "맛있는 한식당입니다",
+                    telephone = "02-1234-5678",
+                    address = "강남구 테헤란로 123",
+                    roadAddress = "서울특별시 강남구 테헤란로 123",
+                    mapX = "127.027619",
+                    mapY = "37.497952"
+                ),
+                NaverLocalSearchItem(
+                    title = "한식당2",
+                    link = "https://map.naver.com/v5/entry/place/0987654321",
+                    category = "한식",
+                    description = "전통 한식당입니다",
+                    telephone = "02-9876-5432",
+                    address = "강남구 역삼동 456",
+                    roadAddress = "서울특별시 강남구 역삼동 456",
+                    mapX = "127.028000",
+                    mapY = "37.498000"
+                )
+            )
+        )
+    }
+
+    private fun createMockResponseForCategory(category: String): NaverLocalSearchResponse {
+        return NaverLocalSearchResponse(
+            lastBuildDate = "2024-01-01T00:00:00.000+09:00",
+            total = 1,
+            start = 1,
+            display = 1,
+            items = listOf(
+                NaverLocalSearchItem(
+                    title = "${category}당",
+                    link = "https://map.naver.com/v5/entry/place/1234567890",
+                    category = category,
+                    description = "맛있는 ${category}당입니다",
+                    telephone = "02-1234-5678",
+                    address = "강남구 테헤란로 123",
+                    roadAddress = "서울특별시 강남구 테헤란로 123",
+                    mapX = "127.027619",
+                    mapY = "37.497952"
+                )
+            )
+        )
+    }
+}

--- a/module-infra/src/test/kotlin/org/depromeet/team3/naver/service/SimpleNaverTest.kt
+++ b/module-infra/src/test/kotlin/org/depromeet/team3/naver/service/SimpleNaverTest.kt
@@ -1,0 +1,57 @@
+package org.depromeet.team3.naver.service
+
+import org.depromeet.team3.naver.dto.NaverLocalSearchResponse
+import org.junit.jupiter.api.Test
+import org.springframework.web.client.RestClient
+import kotlin.test.assertTrue
+
+class SimpleNaverTest {
+
+    @Test
+    fun `Naver API 간단 테스트`() {
+        val clientId = ""
+        val clientSecret = ""
+        val baseUrl = "https://openapi.naver.com/v1/search"
+        
+        val restClient = RestClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeaders { headers ->
+                headers.set("X-Naver-Client-Id", clientId)
+                headers.set("X-Naver-Client-Secret", clientSecret)
+                headers.set("Accept", "application/json")
+            }
+            .build()
+
+        try {
+            val response = restClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder
+                        .path("/local.json")
+                        .queryParam("query", "한식 강남역")
+                        .queryParam("display", 3)
+                        .queryParam("sort", "comment")
+                        .build()
+                }
+                .retrieve()
+                .body(NaverLocalSearchResponse::class.java)
+
+            assertTrue(response != null, "정상 응답 실패")
+            
+            response.items.forEachIndexed { index, item ->
+                println("${index + 1}. ${item.title}")
+                println("   카테고리: ${item.category}")
+                println("   주소: ${item.address}")
+                println("   도로명주소: ${item.roadAddress}")
+                println("   전화번호: ${item.telephone ?: "정보 없음"}")
+                println("   설명: ${item.description}")
+                println("   좌표: (${item.mapX}, ${item.mapY})")
+                println("   링크: ${item.link}")
+                println()
+            }
+            
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

-


## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Naver 지도 API 연동을 위한 설정을 추가하고 지오코딩·지역검색용 HTTP 클라이언트를 구성했습니다.
  - 환경변수로 클라이언트 ID/시크릿을 설정해 배포 환경에서 안전하게 사용할 수 있습니다.
- 테스트
  - 로컬 검색 응답 DTO와 단위/간단 통합 테스트를 추가해 연동 흐름을 검증했습니다.
- 기타(Chores)
  - 웹/HTTP 클라이언트, 로깅 및 테스트 관련 의존성을 추가하고 설정 파일을 정리했습니다.
  - 프로덕션 설정에 Naver API 구성을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->