### PR TITLE
[SETTING] SecurityTestConfig 추가, 직렬화, validation 관련 의존성 추가

### DIFF
--- a/module-api/build.gradle.kts
+++ b/module-api/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
     
+    // Jackson Kotlin 모듈
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    
     testImplementation("org.mockito:mockito-core:5.1.1")
     testImplementation("org.mockito:mockito-junit-jupiter:5.1.1")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
@@ -31,6 +34,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks {

--- a/module-api/src/main/kotlin/org/depromeet/team3/config/ControllerAdvice.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/config/ControllerAdvice.kt
@@ -4,6 +4,7 @@ import org.depromeet.team3.common.exception.ErrorCode
 import org.depromeet.team3.common.exception.DpmException
 import org.depromeet.team3.common.response.DpmApiResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -20,6 +21,21 @@ class ControllerAdvice {
     fun handleDpmException(e: DpmException): ResponseEntity<DpmApiResponse<Unit>> {
         return ResponseEntity.status(e.errorCode.httpStatus)
             .body(DpmApiResponse.error(e))
+    }
+
+    /**
+     * Validation 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<DpmApiResponse<Unit>> {
+        val errorDetails = mutableMapOf<String, Any?>()
+        
+        e.bindingResult.fieldErrors.forEach { fieldError ->
+            errorDetails[fieldError.field] = fieldError.defaultMessage
+        }
+        
+        return ResponseEntity.status(ErrorCode.INVALID_PARAMETER.httpStatus)
+            .body(DpmApiResponse.error(ErrorCode.INVALID_PARAMETER, errorDetails))
     }
 
     /**

--- a/module-api/src/test/kotlin/org/depromeet/team3/config/SecurityTestConfig.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/config/SecurityTestConfig.kt
@@ -1,0 +1,64 @@
+package org.depromeet.team3.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.depromeet.team3.security.jwt.JwtProperties
+import org.depromeet.team3.security.jwt.JwtTokenProvider
+import org.depromeet.team3.security.util.CookieUtil
+import org.depromeet.team3.security.jwt.AppProperties
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+/**
+ * Security 관련 테스트용 설정 클래스
+ * @WebMvcTest에서 SecurityConfig를 사용할 때 필요한 의존성들을 Mock으로 제공
+ */
+@TestConfiguration
+class SecurityTestConfig {
+
+    @Bean
+    @Primary
+    fun testJwtProperties(): JwtProperties {
+        return JwtProperties(
+            secret = "test-secret-key-for-jwt-token-generation-minimum-256-bits-long",
+            accessTokenValidity = 3600000L, // 1시간
+            refreshTokenValidity = 604800000L // 1주일
+        )
+    }
+
+    @Bean
+    @Primary
+    fun testAppProperties(): AppProperties {
+        return AppProperties(
+            env = "test"
+        )
+    }
+
+    @Bean
+    @Primary
+    fun testCookieUtil(appProperties: AppProperties): CookieUtil {
+        return CookieUtil(appProperties)
+    }
+
+    @Bean
+    @Primary
+    fun testJwtTokenProvider(cookieUtil: CookieUtil, jwtProperties: JwtProperties): JwtTokenProvider {
+        return JwtTokenProvider(cookieUtil, jwtProperties)
+    }
+
+    @Bean
+    @Primary
+    fun testPasswordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    @Primary
+    fun testObjectMapper(): ObjectMapper {
+        return ObjectMapper()
+            .registerModule(KotlinModule.Builder().build())
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #31 

## 🔑 주요 내용
SURVEY 관련 test 진행 중 필요한 전역 설정 및 의존성 추가용으로 브랜치 생성

### test
- test에서 security 관련 설정용 SecurityTestConfig 추가
- Kotlin 모듈이 등록된 ObjectMapper 설정으로 테스트 환경 개선

### api
- 전역 ControllerAdvice에 MethodArgumentNotValidException 핸들러 추가
- Validation 실패 시 400 에러와 상세한 필드별 에러 메시지 제공

### build
- Kotlin 객체 직렬화/역직렬화를 위한 jackson-module-kotlin 의존성 추가

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 요청 검증 실패 시 필드별 오류 메시지를 포함한 일관된 에러 응답을 반환하여 사용자 안내를 개선했습니다.
* 테스트
  * 보안 구성에 대한 테스트 전용 설정을 추가해 WebMvcTest 안정성을 높였습니다.
* 기타
  * Kotlin용 Jackson 모듈 의존성을 추가해 Kotlin 데이터 바인딩 호환성을 강화했습니다.
  * Spring Security 테스트 의존성을 추가해 보안 기능 테스트 지원을 확장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->