### PR TITLE
[FEATURE] 모임별 설문 생성, 조회 API 추가

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/application/CreateSurveyService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/application/CreateSurveyService.kt
@@ -1,0 +1,103 @@
+package org.depromeet.team3.survey.application
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.enums.SurveyCategoryType
+import org.depromeet.team3.meeting.MeetingJpaRepository
+import org.depromeet.team3.meetingattendee.MeetingAttendeeJpaRepository
+import org.depromeet.team3.survey.SurveyRepository
+import org.depromeet.team3.survey.dto.request.SurveyCreateRequest
+import org.depromeet.team3.survey.dto.response.SurveyCreateResponse
+import org.depromeet.team3.survey.exception.SurveyException
+import org.depromeet.team3.survey.Survey
+import org.depromeet.team3.surveycategory.SurveyCategoryRepository
+import org.depromeet.team3.surveyresult.SurveyResult
+import org.depromeet.team3.surveyresult.SurveyResultRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateSurveyService(
+    private val surveyRepository: SurveyRepository,
+    private val surveyResultRepository: SurveyResultRepository,
+    private val surveyCategoryRepository: SurveyCategoryRepository,
+    private val meetingJpaRepository: MeetingJpaRepository,
+    private val meetingAttendeeJpaRepository: MeetingAttendeeJpaRepository
+) {
+    
+    @Transactional
+    fun invoke(meetingId: Long, userId: Long, request: SurveyCreateRequest): SurveyCreateResponse {
+        // 모임 존재 확인
+        if (!meetingJpaRepository.existsById(meetingId)){
+           throw SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("meetingId" to meetingId))
+        }
+        
+        // 인증된 사용자가 자신의 설문만 제출할 수 있도록 검증
+        if (userId != request.participantId) {
+            throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("participantId" to request.participantId))
+        }
+        
+        // 참가자 존재 확인
+        if (!meetingAttendeeJpaRepository.existsByMeetingIdAndUserId(meetingId, request.participantId)) {
+            throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("participantId" to request.participantId))
+        }
+        
+        // 중복 설문 제출 확인
+        if (surveyRepository.existsByMeetingIdAndParticipantId(meetingId, request.participantId)) {
+            throw SurveyException(ErrorCode.SURVEY_ALREADY_SUBMITTED, mapOf("participantId" to request.participantId))
+        }
+        
+        // 설문 생성
+        val survey = Survey(
+            meetingId = meetingId,
+            participantId = request.participantId
+        )
+        val savedSurvey = surveyRepository.save(survey)
+        
+        // 설문 결과 생성 (선택된 카테고리들을 SurveyResult로 저장)
+        val surveyResults = mutableListOf<SurveyResult>()
+        
+        // 선호 음식 카테고리들 찾아서 결과에 추가
+        request.preferredCuisineList.forEach { cuisineName ->
+            val category = surveyCategoryRepository.findByNameAndType(cuisineName, SurveyCategoryType.CUISINE)
+            if (category != null) {
+                surveyResults.add(
+                    SurveyResult(
+                        surveyId = savedSurvey.id ?: throw IllegalStateException("Survey ID is null"),
+                        surveyCategoryId = category.id ?: throw IllegalStateException("Category ID is null")
+                    )
+                )
+            }
+        }
+        
+        // 피해야 하는 재료 카테고리들 찾아서 결과에 추가
+        request.avoidIngredientList.forEach { ingredientName ->
+            val category = surveyCategoryRepository.findByNameAndType(ingredientName, SurveyCategoryType.AVOID_INGREDIENT)
+            if (category != null) {
+                surveyResults.add(
+                    SurveyResult(
+                        surveyId = savedSurvey.id ?: throw IllegalStateException("Survey ID is null"),
+                        surveyCategoryId = category.id ?: throw IllegalStateException("Category ID is null")
+                    )
+                )
+            }
+        }
+        
+        // 원하지 않는 메뉴 카테고리들 찾아서 결과에 추가
+        request.avoidMenuList.forEach { menuName ->
+            val category = surveyCategoryRepository.findByNameAndType(menuName, SurveyCategoryType.AVOID_MENU)
+            if (category != null) {
+                surveyResults.add(
+                    SurveyResult(
+                        surveyId = savedSurvey.id ?: throw IllegalStateException("Survey ID is null"),
+                        surveyCategoryId = category.id ?: throw IllegalStateException("Category ID is null")
+                    )
+                )
+            }
+        }
+        
+        // 설문 결과 저장
+        surveyResultRepository.saveAll(surveyResults)
+        
+        return SurveyCreateResponse()
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/application/GetSurveyListService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/application/GetSurveyListService.kt
@@ -1,0 +1,75 @@
+package org.depromeet.team3.survey.application
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.enums.SurveyCategoryType
+import org.depromeet.team3.meeting.MeetingJpaRepository
+import org.depromeet.team3.meetingattendee.MeetingAttendeeRepository
+import org.depromeet.team3.survey.SurveyRepository
+import org.depromeet.team3.surveyresult.SurveyResultRepository
+import org.depromeet.team3.surveycategory.SurveyCategoryRepository
+import org.depromeet.team3.survey.dto.response.SurveyItemResponse
+import org.depromeet.team3.survey.dto.response.SurveyListResponse
+import org.depromeet.team3.survey.exception.SurveyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetSurveyListService(
+    private val surveyRepository: SurveyRepository,
+    private val surveyResultRepository: SurveyResultRepository,
+    private val surveyCategoryRepository: SurveyCategoryRepository,
+    private val meetingJpaRepository: MeetingJpaRepository,
+    private val meetingAttendeeRepository: MeetingAttendeeRepository
+) {
+    
+    @Transactional(readOnly = true)
+    fun invoke(meetingId: Long, userId: Long): SurveyListResponse {
+        // 모임 존재 확인
+        if (!meetingJpaRepository.existsById(meetingId)) {
+            throw SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("meetingId" to meetingId))
+        }
+        
+        // 사용자가 해당 모임의 참가자인지 확인
+        if (!meetingAttendeeRepository.existsByMeetingIdAndUserId(meetingId, userId)) {
+            throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("userId" to userId))
+        }
+        
+        // 모임의 모든 설문 조회
+        val surveys = surveyRepository.findByMeetingId(meetingId)
+        
+        // 각 설문의 결과 정보와 함께 응답 생성
+        val surveyItems = surveys.map { survey ->
+            val results = surveyResultRepository.findBySurveyId(survey.id!!)
+            
+            // 설문 결과에서 카테고리 정보 조회
+            val preferredCuisineList = mutableListOf<String>()
+            val avoidIngredientList = mutableListOf<String>()
+            val avoidMenuList = mutableListOf<String>()
+            
+            results.forEach { result ->
+                val category = surveyCategoryRepository.findById(result.surveyCategoryId)
+                if (category != null) {
+                    when (category.type) {
+                        SurveyCategoryType.CUISINE -> preferredCuisineList.add(category.name)
+                        SurveyCategoryType.AVOID_INGREDIENT -> avoidIngredientList.add(category.name)
+                        SurveyCategoryType.AVOID_MENU -> avoidMenuList.add(category.name)
+                    }
+                }
+            }
+            
+            // 참가자 정보 조회
+            val participant = meetingAttendeeRepository.findByMeetingIdAndUserId(meetingId, survey.participantId)
+                ?: throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("participantId" to survey.participantId))
+            
+            SurveyItemResponse(
+                participantId = survey.participantId,
+                nickname = participant.meetingNickname,
+                preferredCuisineList = preferredCuisineList,
+                avoidIngredientList = avoidIngredientList,
+                avoidMenuList = avoidMenuList
+            )
+        }
+        
+        return SurveyListResponse(surveys = surveyItems)
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/controller/SurveyController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/controller/SurveyController.kt
@@ -1,0 +1,66 @@
+package org.depromeet.team3.survey.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.depromeet.team3.common.ContextConstants
+import org.depromeet.team3.common.annotation.UserId
+import org.depromeet.team3.common.response.DpmApiResponse
+import org.depromeet.team3.survey.application.CreateSurveyService
+import org.depromeet.team3.survey.application.GetSurveyListService
+import org.depromeet.team3.survey.dto.request.SurveyCreateRequest
+import org.depromeet.team3.survey.dto.response.SurveyCreateResponse
+import org.depromeet.team3.survey.dto.response.SurveyListResponse
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "설문", description = "설문 관리 API")
+@RestController
+@RequestMapping("${ContextConstants.API_VERSION_V1}/meetings/{meetingId}/surveys")
+class SurveyController(
+    private val createSurveyService: CreateSurveyService,
+    private val getSurveyListService: GetSurveyListService
+) {
+
+    @Operation(
+        summary = "모임별 설문 생성",
+        description = "특정 모임에 대한 설문을 생성합니다."
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "설문 생성 성공"),
+        ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        ApiResponse(responseCode = "404", description = "모임 또는 참가자를 찾을 수 없음"),
+        ApiResponse(responseCode = "409", description = "중복 설문 제출")
+    )
+    @PostMapping
+    fun createSurvey(
+        @Parameter(description = "모임 ID", example = "1")
+        @PathVariable meetingId: Long,
+        @Parameter(description = "사용자 ID", example = "123")
+        @UserId userId: Long,
+        @RequestBody @Valid request: SurveyCreateRequest
+    ): DpmApiResponse<SurveyCreateResponse> {
+        val response = createSurveyService.invoke(meetingId, userId, request)
+        return DpmApiResponse.ok(response)
+    }
+
+    @Operation(
+        summary = "모임별 전체 설문 결과 조회",
+        description = "특정 모임의 모든 설문 결과를 조회합니다."
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "설문 결과 조회 성공"),
+        ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음")
+    )
+    @GetMapping
+    fun getSurveyList(
+        @Parameter(description = "모임 ID", example = "1")
+        @PathVariable meetingId: Long,
+        @UserId userId: Long
+    ): DpmApiResponse<SurveyListResponse> {
+        val response = getSurveyListService.invoke(meetingId, userId)
+        return DpmApiResponse.ok(response)
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/dto/request/SurveyCreateRequest.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/dto/request/SurveyCreateRequest.kt
@@ -1,0 +1,19 @@
+package org.depromeet.team3.survey.dto.request
+
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class SurveyCreateRequest(
+    @field:NotNull(message = "참가자 ID는 필수입니다")
+    val participantId: Long,
+    
+    @field:NotEmpty(message = "닉네임은 필수입니다")
+    val nickname: String,
+    
+    @field:NotEmpty(message = "선호 음식 목록은 필수입니다")
+    val preferredCuisineList: List<String>,
+    
+    val avoidIngredientList: List<String> = emptyList(),
+    
+    val avoidMenuList: List<String> = emptyList()
+)

--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/dto/response/SurveyResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/dto/response/SurveyResponse.kt
@@ -1,0 +1,17 @@
+package org.depromeet.team3.survey.dto.response
+
+data class SurveyCreateResponse(
+    val message: String = "설문 제출이 완료되었습니다"
+)
+
+data class SurveyItemResponse(
+    val participantId: Long,
+    val nickname: String,
+    val preferredCuisineList: List<String>,
+    val avoidIngredientList: List<String>,
+    val avoidMenuList: List<String>
+)
+
+data class SurveyListResponse(
+    val surveys: List<SurveyItemResponse>
+)

--- a/module-api/src/test/kotlin/org/depromeet/team3/survey/application/CreateSurveyServiceTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/survey/application/CreateSurveyServiceTest.kt
@@ -1,0 +1,176 @@
+package org.depromeet.team3.survey.application
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.enums.SurveyCategoryType
+import org.depromeet.team3.meetingattendee.MeetingAttendeeJpaRepository
+import org.depromeet.team3.meeting.MeetingJpaRepository
+import org.depromeet.team3.survey.Survey
+import org.depromeet.team3.survey.SurveyRepository
+import org.depromeet.team3.survey.dto.request.SurveyCreateRequest
+import org.depromeet.team3.survey.exception.SurveyException
+import org.depromeet.team3.survey.util.SurveyTestDataFactory
+import org.depromeet.team3.surveycategory.SurveyCategory
+import org.depromeet.team3.surveycategory.SurveyCategoryRepository
+import org.depromeet.team3.surveycategory.SurveyCategoryLevel
+import org.depromeet.team3.surveyresult.SurveyResultRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("[SURVEY] 설문 생성 서비스 테스트")
+class CreateSurveyServiceTest {
+
+    @Mock
+    private lateinit var surveyRepository: SurveyRepository
+
+    @Mock
+    private lateinit var surveyResultRepository: SurveyResultRepository
+
+    @Mock
+    private lateinit var surveyCategoryRepository: SurveyCategoryRepository
+
+    @Mock
+    private lateinit var meetingJpaRepository: MeetingJpaRepository
+
+    @Mock
+    private lateinit var meetingAttendeeJpaRepository: MeetingAttendeeJpaRepository
+
+    private lateinit var createSurveyService: CreateSurveyService
+
+    @BeforeEach
+    fun setUp() {
+        createSurveyService = CreateSurveyService(
+            surveyRepository,
+            surveyResultRepository,
+            surveyCategoryRepository,
+            meetingJpaRepository,
+            meetingAttendeeJpaRepository
+        )
+    }
+
+    @Test
+    @DisplayName("설문을 성공적으로 생성한다")
+    fun `설문을 성공적으로 생성한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 1L
+        val participantId = 1L
+        
+        val testScenario = SurveyTestDataFactory.createSurveyTestScenario(
+            meetingId = meetingId,
+            participantId = participantId
+        )
+
+        // Mock 설정
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeJpaRepository.existsByMeetingIdAndUserId(meetingId, participantId)).thenReturn(true)
+        whenever(surveyRepository.existsByMeetingIdAndParticipantId(meetingId, participantId)).thenReturn(false)
+        whenever(surveyRepository.save(any())).thenReturn(testScenario.survey)
+        whenever(surveyCategoryRepository.findByNameAndType("한식", SurveyCategoryType.CUISINE))
+            .thenReturn(testScenario.cuisineCategory)
+        whenever(surveyCategoryRepository.findByNameAndType("일식", SurveyCategoryType.CUISINE))
+            .thenReturn(testScenario.japaneseCuisineCategory)
+        whenever(surveyCategoryRepository.findByNameAndType("글루텐", SurveyCategoryType.AVOID_INGREDIENT))
+            .thenReturn(testScenario.ingredientCategory)
+        whenever(surveyCategoryRepository.findByNameAndType("내장", SurveyCategoryType.AVOID_MENU))
+            .thenReturn(null)
+        whenever(surveyResultRepository.saveAll(any())).thenReturn(emptyList())
+
+        // when
+        val result = createSurveyService.invoke(meetingId, userId, testScenario.request)
+
+        // then
+        assert(result.message == "설문 제출이 완료되었습니다")
+        verify(surveyRepository).save(any())
+        verify(surveyResultRepository).saveAll(any())
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임에 설문 생성 시 예외가 발생한다")
+    fun `존재하지 않는 모임에 설문 생성 시 예외가 발생한다`() {
+        // given
+        val meetingId = 999L
+        val userId = 1L
+        val request = SurveyTestDataFactory.createMinimalSurveyCreateRequest()
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(false)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            createSurveyService.invoke(meetingId, userId, request)
+        }
+
+        assert(exception.errorCode == ErrorCode.MEETING_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 참가자가 설문 생성 시 예외가 발생한다")
+    fun `존재하지 않는 참가자가 설문 생성 시 예외가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 999L
+        val participantId = 999L
+        val request = SurveyTestDataFactory.createMinimalSurveyCreateRequest(participantId = participantId)
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeJpaRepository.existsByMeetingIdAndUserId(meetingId, participantId)).thenReturn(false)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            createSurveyService.invoke(meetingId, userId, request)
+        }
+
+        assert(exception.errorCode == ErrorCode.PARTICIPANT_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("중복 설문 제출 시 예외가 발생한다")
+    fun `중복 설문 제출 시 예외가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 1L
+        val participantId = 1L
+        val request = SurveyTestDataFactory.createMinimalSurveyCreateRequest(participantId = participantId)
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeJpaRepository.existsByMeetingIdAndUserId(meetingId, participantId)).thenReturn(true)
+        whenever(surveyRepository.existsByMeetingIdAndParticipantId(meetingId, participantId)).thenReturn(true)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            createSurveyService.invoke(meetingId, userId, request)
+        }
+
+        assert(exception.errorCode == ErrorCode.SURVEY_ALREADY_SUBMITTED)
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 설문을 제출하려고 할 때 예외가 발생한다")
+    fun `다른 사용자의 설문을 제출하려고 할 때 예외가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 1L
+        val participantId = 999L // 다른 사용자 ID
+        val request = SurveyTestDataFactory.createSurveyCreateRequest(
+            participantId = participantId,
+            nickname = "다른사용자"
+        )
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            createSurveyService.invoke(meetingId, userId, request)
+        }
+
+        assert(exception.errorCode == ErrorCode.PARTICIPANT_NOT_FOUND)
+    }
+}

--- a/module-api/src/test/kotlin/org/depromeet/team3/survey/application/GetSurveyListServiceTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/survey/application/GetSurveyListServiceTest.kt
@@ -1,0 +1,231 @@
+package org.depromeet.team3.survey.application
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.enums.SurveyCategoryType
+import org.depromeet.team3.meetingattendee.MeetingAttendee
+import org.depromeet.team3.meetingattendee.MeetingAttendeeRepository
+import org.depromeet.team3.meetingattendee.util.MeetingAttendeeTestDataFactory
+import org.depromeet.team3.meeting.MeetingEntity
+import org.depromeet.team3.meeting.MeetingJpaRepository
+import org.depromeet.team3.meeting.util.MeetingTestDataFactory
+import org.depromeet.team3.station.StationEntity
+import org.depromeet.team3.station.util.StationTestDataFactory
+import org.depromeet.team3.user.UserEntity
+import org.depromeet.team3.user.util.UserTestDataFactory
+import org.depromeet.team3.survey.Survey
+import org.depromeet.team3.survey.SurveyRepository
+import org.depromeet.team3.survey.exception.SurveyException
+import org.depromeet.team3.survey.util.SurveyTestDataFactory
+import org.depromeet.team3.surveycategory.SurveyCategory
+import org.depromeet.team3.surveycategory.SurveyCategoryRepository
+import org.depromeet.team3.surveycategory.SurveyCategoryLevel
+import org.depromeet.team3.surveyresult.SurveyResult
+import org.depromeet.team3.surveyresult.SurveyResultRepository
+import org.depromeet.team3.surveyresult.util.SurveyResultTestDataFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("[SURVEY] 설문 목록 조회 서비스 테스트")
+class GetSurveyListServiceTest {
+
+    @Mock
+    private lateinit var surveyRepository: SurveyRepository
+
+    @Mock
+    private lateinit var surveyResultRepository: SurveyResultRepository
+
+    @Mock
+    private lateinit var surveyCategoryRepository: SurveyCategoryRepository
+
+    @Mock
+    private lateinit var meetingJpaRepository: MeetingJpaRepository
+
+    @Mock
+    private lateinit var meetingAttendeeRepository: MeetingAttendeeRepository
+
+    private lateinit var getSurveyListService: GetSurveyListService
+
+    @BeforeEach
+    fun setUp() {
+        getSurveyListService = GetSurveyListService(
+            surveyRepository,
+            surveyResultRepository,
+            surveyCategoryRepository,
+            meetingJpaRepository,
+            meetingAttendeeRepository
+        )
+    }
+
+    @Test
+    @DisplayName("설문 목록을 성공적으로 조회한다")
+    fun `설문 목록을 성공적으로 조회한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 1L
+        val participantId1 = 1L
+        val participantId2 = 2L
+
+        val meetingEntity = MeetingTestDataFactory.createMeetingEntity(
+            id = meetingId,
+            hostUser = UserTestDataFactory.createUserEntity(nickname = "테스트호스트"),
+            station = StationTestDataFactory.createStationEntity(name = "테스트역")
+        )
+
+        val attendee = MeetingAttendeeTestDataFactory.createMeetingAttendee(
+            meetingId = meetingId,
+            userId = userId,
+            meetingNickname = "조회자"
+        )
+
+        val survey1 = SurveyTestDataFactory.createSurvey(
+            id = 1L,
+            meetingId = meetingId,
+            participantId = participantId1
+        )
+
+        val survey2 = SurveyTestDataFactory.createSurvey(
+            id = 2L,
+            meetingId = meetingId,
+            participantId = participantId2
+        )
+
+        val surveyResults1 = SurveyResultTestDataFactory.createSurveyResultList(
+            surveyId = 1L,
+            categoryIds = listOf(1L, 2L)
+        )
+
+        val surveyResults2 = SurveyResultTestDataFactory.createSurveyResultList(
+            surveyId = 2L,
+            categoryIds = listOf(3L)
+        )
+
+        val cuisineCategory = SurveyTestDataFactory.createSurveyCategory(
+            id = 1L,
+            type = SurveyCategoryType.CUISINE,
+            name = "한식"
+        )
+        val ingredientCategory = SurveyTestDataFactory.createSurveyCategory(
+            id = 2L,
+            type = SurveyCategoryType.AVOID_INGREDIENT,
+            name = "글루텐"
+        )
+        val menuCategory = SurveyTestDataFactory.createSurveyCategory(
+            id = 3L,
+            type = SurveyCategoryType.AVOID_MENU,
+            name = "내장"
+        )
+
+        val participant1 = MeetingAttendeeTestDataFactory.createMeetingAttendee(
+            id = 1L,
+            meetingId = meetingId,
+            userId = participantId1,
+            meetingNickname = "참가자1"
+        )
+
+        val participant2 = MeetingAttendeeTestDataFactory.createMeetingAttendee(
+            id = 2L,
+            meetingId = meetingId,
+            userId = participantId2,
+            meetingNickname = "참가자2"
+        )
+
+        // Mock 설정
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeRepository.existsByMeetingIdAndUserId(meetingId, userId)).thenReturn(true)
+        whenever(surveyRepository.findByMeetingId(meetingId)).thenReturn(listOf(survey1, survey2))
+        whenever(surveyResultRepository.findBySurveyId(1L)).thenReturn(surveyResults1)
+        whenever(surveyResultRepository.findBySurveyId(2L)).thenReturn(surveyResults2)
+        whenever(surveyCategoryRepository.findById(1L)).thenReturn(cuisineCategory)
+        whenever(surveyCategoryRepository.findById(2L)).thenReturn(ingredientCategory)
+        whenever(surveyCategoryRepository.findById(3L)).thenReturn(menuCategory)
+        whenever(meetingAttendeeRepository.findByMeetingIdAndUserId(meetingId, participantId1)).thenReturn(participant1)
+        whenever(meetingAttendeeRepository.findByMeetingIdAndUserId(meetingId, participantId2)).thenReturn(participant2)
+
+        // when
+        val result = getSurveyListService.invoke(meetingId, userId)
+
+        // then
+        assert(result.surveys.size == 2)
+        
+        val surveyItem1 = result.surveys.find { it.participantId == participantId1 }
+        assert(surveyItem1 != null)
+        assert(surveyItem1!!.nickname == "참가자1")
+        assert(surveyItem1.preferredCuisineList.contains("한식"))
+        assert(surveyItem1.avoidIngredientList.contains("글루텐"))
+        assert(surveyItem1.avoidMenuList.isEmpty())
+
+        val surveyItem2 = result.surveys.find { it.participantId == participantId2 }
+        assert(surveyItem2 != null)
+        assert(surveyItem2!!.nickname == "참가자2")
+        assert(surveyItem2.preferredCuisineList.isEmpty())
+        assert(surveyItem2.avoidIngredientList.isEmpty())
+        assert(surveyItem2.avoidMenuList.contains("내장"))
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임 조회 시 예외가 발생한다")
+    fun `존재하지 않는 모임 조회 시 예외가 발생한다`() {
+        // given
+        val meetingId = 999L
+        val userId = 1L
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(false)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            getSurveyListService.invoke(meetingId, userId)
+        }
+
+        assert(exception.errorCode == ErrorCode.MEETING_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("모임 참가자가 아닌 사용자가 조회 시 예외가 발생한다")
+    fun `모임 참가자가 아닌 사용자가 조회 시 예외가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 999L
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeRepository.existsByMeetingIdAndUserId(meetingId, userId)).thenReturn(false)
+
+        // when & then
+        val exception = assertThrows<SurveyException> {
+            getSurveyListService.invoke(meetingId, userId)
+        }
+
+        assert(exception.errorCode == ErrorCode.PARTICIPANT_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("설문이 없는 모임 조회 시 빈 목록을 반환한다")
+    fun `설문이 없는 모임 조회 시 빈 목록을 반환한다`() {
+        // given
+        val meetingId = 1L
+        val userId = 1L
+
+        val attendee = MeetingAttendeeTestDataFactory.createMeetingAttendee(
+            id = 1L,
+            meetingId = meetingId,
+            userId = userId,
+            meetingNickname = "조회자"
+        )
+
+        whenever(meetingJpaRepository.existsById(meetingId)).thenReturn(true)
+        whenever(meetingAttendeeRepository.existsByMeetingIdAndUserId(meetingId, userId)).thenReturn(true)
+        whenever(surveyRepository.findByMeetingId(meetingId)).thenReturn(emptyList())
+
+        // when
+        val result = getSurveyListService.invoke(meetingId, userId)
+
+        // then
+        assert(result.surveys.isEmpty())
+    }
+}

--- a/module-api/src/test/kotlin/org/depromeet/team3/survey/controller/SurveyControllerTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/survey/controller/SurveyControllerTest.kt
@@ -1,0 +1,232 @@
+package org.depromeet.team3.survey.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.common.util.TestAuthHelper
+import org.depromeet.team3.config.SecurityTestConfig
+import org.depromeet.team3.survey.application.CreateSurveyService
+import org.depromeet.team3.survey.application.GetSurveyListService
+import org.depromeet.team3.survey.dto.request.SurveyCreateRequest
+import org.depromeet.team3.survey.dto.response.SurveyCreateResponse
+import org.depromeet.team3.survey.dto.response.SurveyItemResponse
+import org.depromeet.team3.survey.dto.response.SurveyListResponse
+import org.depromeet.team3.survey.exception.SurveyException
+import org.depromeet.team3.survey.util.SurveyTestDataFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@WebMvcTest(SurveyController::class)
+@Import(SecurityTestConfig::class)
+@ActiveProfiles("test")
+@DisplayName("[SURVEY] 설문 컨트롤러 테스트")
+class SurveyControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var createSurveyService: CreateSurveyService
+
+    @MockitoBean
+    private lateinit var getSurveyListService: GetSurveyListService
+
+    @BeforeEach
+    fun setUp() {
+        // 테스트용 사용자 인증 설정
+        TestAuthHelper.setAuthenticatedUser(1L)
+    }
+
+    @Test
+    @DisplayName("설문을 성공적으로 생성한다")
+    fun `설문을 성공적으로 생성한다`() {
+        // given
+        val meetingId = 1L
+        val request = SurveyTestDataFactory.createSurveyCreateRequest()
+        val response = SurveyTestDataFactory.createSurveyCreateResponse()
+
+        `when`(createSurveyService.invoke(any(), any(), any())).thenReturn(response)
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/meetings/$meetingId/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.message").value("설문 제출이 완료되었습니다"))
+            .andExpect(jsonPath("$.error").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("설문 목록을 성공적으로 조회한다")
+    fun `설문 목록을 성공적으로 조회한다`() {
+        // given
+        val meetingId = 1L
+        val response = SurveyTestDataFactory.createSurveyListResponse()
+
+        `when`(getSurveyListService.invoke(any(), any())).thenReturn(response)
+
+        // when & then
+        mockMvc.perform(get("/api/v1/meetings/$meetingId/surveys"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.surveys").isArray)
+            .andExpect(jsonPath("$.data.surveys[0].participantId").value(1))
+            .andExpect(jsonPath("$.data.surveys[0].nickname").value("참가자1"))
+            .andExpect(jsonPath("$.data.surveys[0].preferredCuisineList").isArray)
+            .andExpect(jsonPath("$.data.surveys[0].preferredCuisineList[0]").value("한식"))
+            .andExpect(jsonPath("$.data.surveys[0].preferredCuisineList[1]").value("일식"))
+            .andExpect(jsonPath("$.data.surveys[0].avoidIngredientList[0]").value("글루텐"))
+            .andExpect(jsonPath("$.data.surveys[0].avoidMenuList[0]").value("내장"))
+            .andExpect(jsonPath("$.data.surveys[1].participantId").value(2))
+            .andExpect(jsonPath("$.data.surveys[1].nickname").value("참가자2"))
+            .andExpect(jsonPath("$.error").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임에 설문 생성 시 404 에러가 발생한다")
+    fun `존재하지 않는 모임에 설문 생성 시 404 에러가 발생한다`() {
+        // given
+        val meetingId = 999L
+        val request = SurveyTestDataFactory.createMinimalSurveyCreateRequest()
+
+        doThrow(SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("meetingId" to meetingId)))
+            .`when`(createSurveyService).invoke(any(), any(), any())
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/meetings/$meetingId/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error.code").value("C4043"))
+    }
+
+    @Test
+    @DisplayName("중복 설문 제출 시 409 에러가 발생한다")
+    fun `중복 설문 제출 시 409 에러가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val request = SurveyTestDataFactory.createMinimalSurveyCreateRequest()
+
+        doThrow(SurveyException(ErrorCode.SURVEY_ALREADY_SUBMITTED, mapOf("participantId" to 1L)))
+            .`when`(createSurveyService).invoke(any(), any(), any())
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/meetings/$meetingId/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error.code").value("C4096"))
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 데이터로 설문 생성 시 400 에러가 발생한다")
+    fun `잘못된 요청 데이터로 설문 생성 시 400 에러가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val invalidRequest = SurveyTestDataFactory.createEmptySurveyCreateRequest(nickname = "")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/meetings/$meetingId/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequest))
+                .with(csrf())
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임 조회 시 404 에러가 발생한다")
+    fun `존재하지 않는 모임 조회 시 404 에러가 발생한다`() {
+        // given
+        val meetingId = 999L
+
+        doThrow(SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("meetingId" to meetingId)))
+            .`when`(getSurveyListService).invoke(any(), any())
+
+        // when & then
+        mockMvc.perform(get("/api/v1/meetings/$meetingId/surveys"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error.code").value("C4043"))
+    }
+
+    @Test
+    @DisplayName("모임 참가자가 아닌 사용자가 조회 시 404 에러가 발생한다")
+    fun `모임 참가자가 아닌 사용자가 조회 시 404 에러가 발생한다`() {
+        // given
+        val meetingId = 1L
+
+        doThrow(SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("userId" to 999L)))
+            .`when`(getSurveyListService).invoke(any(), any())
+
+        // when & then
+        mockMvc.perform(get("/api/v1/meetings/$meetingId/surveys"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error.code").value("C4044"))
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 설문을 제출하려고 할 때 404 에러가 발생한다")
+    fun `다른 사용자의 설문을 제출하려고 할 때 404 에러가 발생한다`() {
+        // given
+        val meetingId = 1L
+        val request = SurveyTestDataFactory.createSurveyCreateRequest(
+            participantId = 999L,
+            nickname = "다른사용자"
+        )
+
+        // Mock 서비스가 PARTICIPANT_NOT_FOUND 예외를 던지도록 설정
+        doThrow(SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("participantId" to 999L)))
+            .`when`(createSurveyService).invoke(any(), any(), any())
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/meetings/$meetingId/surveys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+        )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.error.code").value("C4044"))
+    }
+}

--- a/module-api/src/test/kotlin/org/depromeet/team3/survey/util/SurveyTestDataFactory.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/survey/util/SurveyTestDataFactory.kt
@@ -1,0 +1,196 @@
+package org.depromeet.team3.survey.util
+
+import org.depromeet.team3.common.enums.SurveyCategoryType
+import org.depromeet.team3.survey.Survey
+import org.depromeet.team3.survey.dto.request.SurveyCreateRequest
+import org.depromeet.team3.survey.dto.response.SurveyCreateResponse
+import org.depromeet.team3.survey.dto.response.SurveyItemResponse
+import org.depromeet.team3.survey.dto.response.SurveyListResponse
+import org.depromeet.team3.surveycategory.SurveyCategory
+import org.depromeet.team3.surveycategory.SurveyCategoryLevel
+import org.depromeet.team3.surveyresult.SurveyResult
+import org.depromeet.team3.surveyresult.util.SurveyResultTestDataFactory
+import java.time.LocalDateTime
+
+/**
+ * Survey 관련 테스트 데이터 팩토리 클래스
+ */
+object SurveyTestDataFactory {
+
+    // ========== SurveyCreateRequest 생성 ==========
+    
+    fun createSurveyCreateRequest(
+        participantId: Long = 1L,
+        nickname: String = "테스트참가자",
+        preferredCuisineList: List<String> = listOf("한식", "일식"),
+        avoidIngredientList: List<String> = listOf("글루텐"),
+        avoidMenuList: List<String> = listOf("내장")
+    ): SurveyCreateRequest {
+        return SurveyCreateRequest(
+            participantId = participantId,
+            nickname = nickname,
+            preferredCuisineList = preferredCuisineList,
+            avoidIngredientList = avoidIngredientList,
+            avoidMenuList = avoidMenuList
+        )
+    }
+
+    fun createMinimalSurveyCreateRequest(
+        participantId: Long = 1L,
+        nickname: String = "테스트참가자"
+    ): SurveyCreateRequest {
+        return SurveyCreateRequest(
+            participantId = participantId,
+            nickname = nickname,
+            preferredCuisineList = listOf("한식"),
+            avoidIngredientList = emptyList(),
+            avoidMenuList = emptyList()
+        )
+    }
+
+    fun createEmptySurveyCreateRequest(
+        participantId: Long = 1L,
+        nickname: String = "테스트참가자"
+    ): SurveyCreateRequest {
+        return SurveyCreateRequest(
+            participantId = participantId,
+            nickname = nickname,
+            preferredCuisineList = emptyList(),
+            avoidIngredientList = emptyList(),
+            avoidMenuList = emptyList()
+        )
+    }
+
+    // ========== SurveyCategory 생성 ==========
+    
+    fun createSurveyCategory(
+        id: Long = 1L,
+        parentId: Long? = null,
+        type: SurveyCategoryType = SurveyCategoryType.CUISINE,
+        level: SurveyCategoryLevel = SurveyCategoryLevel.LEAF,
+        name: String = "한식",
+        sortOrder: Int = 1,
+        isDeleted: Boolean = false,
+        createdAt: LocalDateTime = LocalDateTime.now(),
+        updatedAt: LocalDateTime? = null
+    ): SurveyCategory {
+        return SurveyCategory(
+            id = id,
+            parentId = parentId,
+            type = type,
+            level = level,
+            name = name,
+            sortOrder = sortOrder,
+            isDeleted = isDeleted,
+            createdAt = createdAt,
+            updatedAt = updatedAt
+        )
+    }
+
+    // ========== Survey 엔티티 생성 ==========
+    
+    fun createSurvey(
+        id: Long = 1L,
+        meetingId: Long = 1L,
+        participantId: Long = 1L
+    ): Survey {
+        return Survey(
+            id = id,
+            meetingId = meetingId,
+            participantId = participantId
+        )
+    }
+
+    // ========== SurveyResult 생성 ==========
+    
+    fun createSurveyResult(
+        id: Long = 1L,
+        surveyId: Long = 1L,
+        surveyCategoryId: Long = 1L
+    ): SurveyResult {
+        return SurveyResultTestDataFactory.createSurveyResult(
+            id = id,
+            surveyId = surveyId,
+            surveyCategoryId = surveyCategoryId
+        )
+    }
+
+
+    // ========== Response DTO 생성 ==========
+    
+    fun createSurveyCreateResponse(): SurveyCreateResponse {
+        return SurveyCreateResponse()
+    }
+
+    fun createSurveyItemResponse(
+        participantId: Long = 1L,
+        nickname: String = "참가자1",
+        preferredCuisineList: List<String> = listOf("한식", "일식"),
+        avoidIngredientList: List<String> = listOf("글루텐"),
+        avoidMenuList: List<String> = listOf("내장")
+    ): SurveyItemResponse {
+        return SurveyItemResponse(
+            participantId = participantId,
+            nickname = nickname,
+            preferredCuisineList = preferredCuisineList,
+            avoidIngredientList = avoidIngredientList,
+            avoidMenuList = avoidMenuList
+        )
+    }
+
+    fun createSurveyListResponse(
+        surveys: List<SurveyItemResponse> = listOf(
+            createSurveyItemResponse(),
+            createSurveyItemResponse(
+                participantId = 2L,
+                nickname = "참가자2",
+                preferredCuisineList = listOf("양식"),
+                avoidIngredientList = emptyList(),
+                avoidMenuList = listOf("치즈")
+            )
+        )
+    ): SurveyListResponse {
+        return SurveyListResponse(surveys = surveys)
+    }
+
+    // ========== 복합 데이터 생성 ==========
+    
+    fun createSurveyTestScenario(
+        meetingId: Long = 1L,
+        participantId: Long = 1L
+    ): SurveyTestScenario {
+        return SurveyTestScenario(
+            meetingId = meetingId,
+            participantId = participantId,
+            request = createSurveyCreateRequest(participantId = participantId),
+            survey = createSurvey(meetingId = meetingId, participantId = participantId),
+            cuisineCategory = createSurveyCategory(
+                id = 1L,
+                type = SurveyCategoryType.CUISINE,
+                name = "한식"
+            ),
+            japaneseCuisineCategory = createSurveyCategory(
+                id = 3L,
+                type = SurveyCategoryType.CUISINE,
+                name = "일식"
+            ),
+            ingredientCategory = createSurveyCategory(
+                id = 2L,
+                type = SurveyCategoryType.AVOID_INGREDIENT,
+                name = "글루텐"
+            ),
+            response = createSurveyCreateResponse()
+        )
+    }
+
+    data class SurveyTestScenario(
+        val meetingId: Long,
+        val participantId: Long,
+        val request: SurveyCreateRequest,
+        val survey: Survey,
+        val cuisineCategory: SurveyCategory,
+        val japaneseCuisineCategory: SurveyCategory,
+        val ingredientCategory: SurveyCategory,
+        val response: SurveyCreateResponse
+    )
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/enums/SurveyCategoryType.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/enums/SurveyCategoryType.kt
@@ -1,0 +1,7 @@
+package org.depromeet.team3.common.enums
+
+enum class SurveyCategoryType {
+    CUISINE,           // 선호하는 음식
+    AVOID_INGREDIENT,  // 피해야 하는 재료
+    AVOID_MENU         // 원하지 않는 메뉴
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/survey/Survey.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/survey/Survey.kt
@@ -1,0 +1,12 @@
+package org.depromeet.team3.survey
+
+import org.depromeet.team3.common.BaseTimeDomain
+import java.time.LocalDateTime
+
+data class Survey(
+    val id: Long? = null,
+    val meetingId: Long,
+    val participantId: Long,
+    override val createdAt: LocalDateTime? = null,
+    override val updatedAt: LocalDateTime? = null,
+) : BaseTimeDomain(createdAt, updatedAt)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/survey/SurveyRepository.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/survey/SurveyRepository.kt
@@ -1,0 +1,8 @@
+package org.depromeet.team3.survey
+
+interface SurveyRepository {
+    fun save(survey: Survey): Survey
+    fun findByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): Survey?
+    fun findByMeetingId(meetingId: Long): List<Survey>
+    fun existsByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): Boolean
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/survey/exception/SurveyException.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/survey/exception/SurveyException.kt
@@ -1,0 +1,9 @@
+package org.depromeet.team3.survey.exception
+
+import org.depromeet.team3.common.exception.DpmException
+import org.depromeet.team3.common.exception.ErrorCode
+
+class SurveyException(
+    errorCode: ErrorCode,
+    details: Map<String, Any> = emptyMap()
+) : DpmException(errorCode, details)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResult.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResult.kt
@@ -1,0 +1,12 @@
+package org.depromeet.team3.surveyresult
+
+import org.depromeet.team3.common.BaseTimeDomain
+import java.time.LocalDateTime
+
+data class SurveyResult(
+    val id: Long? = null,
+    val surveyId: Long,
+    val surveyCategoryId: Long,
+    override val createdAt: LocalDateTime? = null,
+    override val updatedAt: LocalDateTime? = null,
+) : BaseTimeDomain(createdAt, updatedAt)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultRepository.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultRepository.kt
@@ -1,0 +1,7 @@
+package org.depromeet.team3.surveyresult
+
+interface SurveyResultRepository {
+    fun save(surveyResult: SurveyResult): SurveyResult
+    fun saveAll(surveyResults: List<SurveyResult>): List<SurveyResult>
+    fun findBySurveyId(surveyId: Long): List<SurveyResult>
+}

--- a/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/exception/SurveyResultException.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/surveyresult/exception/SurveyResultException.kt
@@ -1,0 +1,9 @@
+package org.depromeet.team3.surveyresult.exception
+
+import org.depromeet.team3.common.exception.DpmException
+import org.depromeet.team3.common.exception.ErrorCode
+
+class SurveyResultException(
+    errorCode: ErrorCode,
+    details: Map<String, Any> = emptyMap()
+) : DpmException(errorCode, details)

--- a/module-domain/src/test/kotlin/org/depromeet/team3/survey/SurveyTest.kt
+++ b/module-domain/src/test/kotlin/org/depromeet/team3/survey/SurveyTest.kt
@@ -1,0 +1,27 @@
+package org.depromeet.team3.survey
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[SURVEY] 설문 도메인 테스트")
+class SurveyTest {
+
+    @Test
+    @DisplayName("Survey 도메인 객체를 생성한다")
+    fun `Survey 도메인 객체를 생성한다`() {
+        // given
+        val meetingId = 1L
+        val participantId = 2L
+
+        // when
+        val survey = Survey(
+            meetingId = meetingId,
+            participantId = participantId
+        )
+
+        // then
+        assert(survey.meetingId == meetingId)
+        assert(survey.participantId == participantId)
+        assert(survey.id == null)
+    }
+}

--- a/module-domain/src/test/kotlin/org/depromeet/team3/surveyresult/SurveyResultTest.kt
+++ b/module-domain/src/test/kotlin/org/depromeet/team3/surveyresult/SurveyResultTest.kt
@@ -1,0 +1,27 @@
+package org.depromeet.team3.surveyresult
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[SURVEY RESULT] 설문 결과 도메인 테스트")
+class SurveyResultTest {
+
+    @Test
+    @DisplayName("SurveyResult 도메인 객체를 생성한다")
+    fun `SurveyResult 도메인 객체를 생성한다`() {
+        // given
+        val surveyId = 1L
+        val surveyCategoryId = 2L
+
+        // when
+        val surveyResult = SurveyResult(
+            surveyId = surveyId,
+            surveyCategoryId = surveyCategoryId
+        )
+
+        // then
+        assert(surveyResult.surveyId == surveyId)
+        assert(surveyResult.surveyCategoryId == surveyCategoryId)
+        assert(surveyResult.id == null)
+    }
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/mapper/SurveyMapper.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/mapper/SurveyMapper.kt
@@ -1,0 +1,40 @@
+package org.depromeet.team3.mapper
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.survey.Survey
+import org.depromeet.team3.survey.SurveyEntity
+import org.depromeet.team3.survey.exception.SurveyException
+import org.depromeet.team3.meeting.MeetingJpaRepository
+import org.depromeet.team3.meetingattendee.MeetingAttendeeJpaRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SurveyMapper(
+    private val meetingJpaRepository: MeetingJpaRepository,
+    private val meetingAttendeeJpaRepository: MeetingAttendeeJpaRepository
+) : DomainMapper<Survey, SurveyEntity> {
+    
+    override fun toDomain(entity: SurveyEntity): Survey {
+        return Survey(
+            id = entity.id,
+            meetingId = entity.meeting.id ?: throw SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("message" to "Meeting ID cannot be null")),
+            participantId = entity.participant.id ?: throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("message" to "Participant ID cannot be null")),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    override fun toEntity(domain: Survey): SurveyEntity {
+        val meetingEntity = meetingJpaRepository.findById(domain.meetingId)
+            .orElseThrow { SurveyException(ErrorCode.MEETING_NOT_FOUND, mapOf("meetingId" to domain.meetingId)) }
+
+        val participantEntity = meetingAttendeeJpaRepository.findByMeetingIdAndUserId(domain.meetingId, domain.participantId)
+            ?: throw SurveyException(ErrorCode.PARTICIPANT_NOT_FOUND, mapOf("meetingId" to domain.meetingId, "participantId" to domain.participantId))
+        
+        return SurveyEntity(
+            id = domain.id,
+            meeting = meetingEntity,
+            participant = participantEntity
+        )
+    }
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/mapper/SurveyResultMapper.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/mapper/SurveyResultMapper.kt
@@ -1,0 +1,40 @@
+package org.depromeet.team3.mapper
+
+import org.depromeet.team3.common.exception.ErrorCode
+import org.depromeet.team3.survey.SurveyJpaRepository
+import org.depromeet.team3.surveycategory.SurveyCategoryJpaRepository
+import org.depromeet.team3.surveyresult.SurveyResult
+import org.depromeet.team3.surveyresult.SurveyResultEntity
+import org.depromeet.team3.surveyresult.exception.SurveyResultException
+import org.springframework.stereotype.Component
+
+@Component
+class SurveyResultMapper(
+    private val surveyJpaRepository: SurveyJpaRepository,
+    private val surveyCategoryJpaRepository: SurveyCategoryJpaRepository
+) : DomainMapper<SurveyResult, SurveyResultEntity> {
+    
+    override fun toDomain(entity: SurveyResultEntity): SurveyResult {
+        return SurveyResult(
+            id = entity.id,
+            surveyId = entity.survey.id ?: throw SurveyResultException(ErrorCode.SURVEY_NOT_FOUND, mapOf("message" to "Survey ID cannot be null")),
+            surveyCategoryId = entity.surveyCategory.id ?: throw SurveyResultException(ErrorCode.CATEGORY_NOT_FOUND, mapOf("message" to "SurveyCategory ID cannot be null")),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    override fun toEntity(domain: SurveyResult): SurveyResultEntity {
+        val surveyEntity = surveyJpaRepository.findById(domain.surveyId)
+            .orElseThrow { SurveyResultException(ErrorCode.SURVEY_NOT_FOUND, mapOf("surveyId" to domain.surveyId)) }
+
+        val surveyCategoryEntity = surveyCategoryJpaRepository.findById(domain.surveyCategoryId)
+            .orElseThrow { SurveyResultException(ErrorCode.CATEGORY_NOT_FOUND, mapOf("surveyCategoryId" to domain.surveyCategoryId)) }
+        
+        return SurveyResultEntity(
+            id = domain.id,
+            survey = surveyEntity,
+            surveyCategory = surveyCategoryEntity
+        )
+    }
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyEntity.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyEntity.kt
@@ -1,0 +1,34 @@
+package org.depromeet.team3.survey
+
+import jakarta.persistence.*
+import org.depromeet.team3.common.BaseTimeEntity
+import org.depromeet.team3.meeting.MeetingEntity
+import org.depromeet.team3.meetingattendee.MeetingAttendeeEntity
+import org.depromeet.team3.surveyresult.SurveyResultEntity
+
+@Entity
+@Table(
+    name = "tb_surveys",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_survey_meeting_participant",
+            columnNames = ["meeting_id", "participant_id"]
+        )
+    ]
+)
+class SurveyEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    val meeting: MeetingEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    val participant: MeetingAttendeeEntity,
+
+    @OneToMany(mappedBy = "survey", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    val surveyResults: MutableList<SurveyResultEntity> = mutableListOf()
+) : BaseTimeEntity()

--- a/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyJpaRepository.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyJpaRepository.kt
@@ -1,0 +1,9 @@
+package org.depromeet.team3.survey
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SurveyJpaRepository : JpaRepository<SurveyEntity, Long> {
+    fun findByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): SurveyEntity?
+    fun findByMeetingId(meetingId: Long): List<SurveyEntity>
+    fun existsByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): Boolean
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyQuery.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/survey/SurveyQuery.kt
@@ -1,0 +1,30 @@
+package org.depromeet.team3.survey
+
+import org.depromeet.team3.mapper.SurveyMapper
+import org.springframework.stereotype.Repository
+
+@Repository
+class SurveyQuery(
+    private val surveyMapper: SurveyMapper,
+    private val surveyJpaRepository: SurveyJpaRepository
+) : SurveyRepository {
+    
+    override fun save(survey: Survey): Survey {
+        val entity = surveyMapper.toEntity(survey)
+        return surveyMapper.toDomain(surveyJpaRepository.save(entity))
+    }
+    
+    override fun findByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): Survey? {
+        return surveyJpaRepository.findByMeetingIdAndParticipantId(meetingId, participantId)
+            ?.let { surveyMapper.toDomain(it) }
+    }
+    
+    override fun findByMeetingId(meetingId: Long): List<Survey> {
+        return surveyJpaRepository.findByMeetingId(meetingId)
+            .map { surveyMapper.toDomain(it) }
+    }
+    
+    override fun existsByMeetingIdAndParticipantId(meetingId: Long, participantId: Long): Boolean {
+        return surveyJpaRepository.existsByMeetingIdAndParticipantId(meetingId, participantId)
+    }
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultEntity.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultEntity.kt
@@ -1,0 +1,22 @@
+package org.depromeet.team3.surveyresult
+
+import jakarta.persistence.*
+import org.depromeet.team3.common.BaseTimeEntity
+import org.depromeet.team3.survey.SurveyEntity
+import org.depromeet.team3.surveycategory.SurveyCategoryEntity
+
+@Entity
+@Table(name = "tb_survey_result")
+class SurveyResultEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    val survey: SurveyEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_category_id", nullable = false)
+    val surveyCategory: SurveyCategoryEntity
+) : BaseTimeEntity()

--- a/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultJpaRepository.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultJpaRepository.kt
@@ -1,0 +1,8 @@
+package org.depromeet.team3.surveyresult
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SurveyResultJpaRepository : JpaRepository<SurveyResultEntity, Long> {
+    fun findBySurveyId(surveyId: Long): List<SurveyResultEntity>
+    fun findBySurveyIdIn(surveyIds: List<Long>): List<SurveyResultEntity>
+}

--- a/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultQuery.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/surveyresult/SurveyResultQuery.kt
@@ -1,0 +1,27 @@
+package org.depromeet.team3.surveyresult
+
+import org.depromeet.team3.mapper.SurveyResultMapper
+import org.springframework.stereotype.Repository
+
+@Repository
+class SurveyResultQuery(
+    private val surveyResultMapper: SurveyResultMapper,
+    private val surveyResultJpaRepository: SurveyResultJpaRepository
+) : SurveyResultRepository {
+    
+    override fun save(surveyResult: SurveyResult): SurveyResult {
+        val entity = surveyResultMapper.toEntity(surveyResult)
+        return surveyResultMapper.toDomain(surveyResultJpaRepository.save(entity))
+    }
+    
+    override fun saveAll(surveyResults: List<SurveyResult>): List<SurveyResult> {
+        val entities = surveyResults.map { surveyResultMapper.toEntity(it) }
+        val savedEntities = surveyResultJpaRepository.saveAll(entities)
+        return savedEntities.map { surveyResultMapper.toDomain(it) }
+    }
+    
+    override fun findBySurveyId(surveyId: Long): List<SurveyResult> {
+        return surveyResultJpaRepository.findBySurveyId(surveyId)
+            .map { surveyResultMapper.toDomain(it) }
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- **브랜치**: `feat/survey-domain-models`
- **이슈**: Survey 도메인 모델 및 API 구현
- #30 

## 🔑 주요 내용

- **Survey 도메인 모델 추가**
  - `Survey` 엔티티 및 도메인 모델 구현
  - `SurveyResult` 엔티티 및 도메인 모델 구현
  - `SurveyCategoryType` ENUM 추가 (CUISINE, AVOID_INGREDIENT, AVOID_MENU)
  - JPA Repository 및 Query 클래스 구현
  - 도메인별 Exception 클래스 추가

- **Survey API 및 서비스 구현**
  - `CreateSurveyService`: 설문 생성 서비스
  - `GetSurveyListService`: 설문 목록 조회 서비스
  - `SurveyController`: 설문 관련 REST API 엔드포인트
  - Request/Response DTO 클래스 구현

- **테스트 코드 추가**
  - 서비스 레이어 단위 테스트 (CreateSurveyServiceTest, GetSurveyListServiceTest)
  - 컨트롤러 레이어 테스트 (SurveyControllerTest)
  - 테스트 데이터 팩토리 클래스 (SurveyTestDataFactory)
  - 도메인 모델 단위 테스트 (SurveyTest, SurveyResultTest)

- **Mapper 클래스 추가**
  - `SurveyMapper`: Survey 도메인 ↔ 엔티티 변환
  - `SurveyResultMapper`: SurveyResult 도메인 ↔ 엔티티 변환

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!