### PR TITLE
[FIX] CI 과정에서 서버 일시 정지되는 문제 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,9 +54,9 @@ pipeline {
                     sh './gradlew --stop || true'
                     sh 'pkill -f "KotlinCompileDaemon" || true'
                     
-                    // Docker 정리
-                    sh 'docker system prune -f || true'
-                    sh 'docker builder prune -f || true'
+                    // Docker 정리(일시적으로 주석 처리)
+                    // sh 'docker system prune -f || true'
+                    // sh 'docker builder prune -f || true'
                 }
             }
         }
@@ -100,16 +100,15 @@ pipeline {
                     echo "Git branch: ${env.GIT_BRANCH}"
                     sh 'echo "Git branch from command: $(git branch --show-current)"'
                     sh 'echo "All git branches: $(git branch -a)"'
-                    
+
                     sh '''
-                        # Kotlin 컴파일 최적화로 빌드
-                            ./gradlew :module-api:clean :module-api:bootJar \
-                            --no-daemon \
-                            --stacktrace \
-                            -x test \
-                            -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=1g" \
-                            -Dkotlin.daemon.jvm.options="-Xmx2g,-XX:MaxMetaspaceSize=512m" \
-                            -Dkotlin.incremental=false
+                    ./gradlew :module-api:clean :module-api:bootJar \
+                    --no-daemon \
+                    --stacktrace \
+                    -x test \
+                    -Dorg.gradle.jvmargs="-Xmx1g -XX:MaxMetaspaceSize=512m" \
+                    -Dkotlin.daemon.jvm.options="-Xmx512m,-XX:MaxMetaspaceSize=256m" \
+                    -Dkotlin.incremental=false
                     '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         DEPLOY_PATH = "/home/ubuntu/momuzzi-server"
         
         // Kotlin 컴파일 최적화
-        GRADLE_OPTS = "-Xmx4g -XX:MaxMetaspaceSize=1g"
+        GRADLE_OPTS = "-Xmx4g -XX:MaxMetaspaceSize=512m"
         
         // Gradle 캐시 설정
         GRADLE_USER_HOME = "${env.WORKSPACE}/.gradle"

--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -62,6 +62,13 @@ services:
     user: root
     networks:
       - depromeet_network
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'     # Jenkins 컨테이너가 사용할 수 있는 최대 CPU (2코어)
+          memory: 3G      # Jenkins 컨테이너 최대 메모리 제한
+        reservations:
+          memory: 1G
 
 volumes:
   registry_data:

--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -62,13 +62,10 @@ services:
     user: root
     networks:
       - depromeet_network
-    deploy:
-      resources:
-        limits:
-          cpus: '2.0'     # Jenkins 컨테이너가 사용할 수 있는 최대 CPU (2코어)
-          memory: 3G      # Jenkins 컨테이너 최대 메모리 제한
-        reservations:
-          memory: 1G
+
+    mem_limit: 3g        # Jenkins 컨테이너 메모리 제한
+    mem_reservation: 1g  # 예약 메모리
+    cpus: 2.0
 
 volumes:
   registry_data:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- 

## 🔑 주요 내용

/var/jenkins_home 볼륨으로 마운트가 안되어서 Jenkins가 직접 서버 디스크에 쓰려다가 문제가 좀 생겼습니다.
그리고 서버 램에 비해 Kotlin 빌드 설정이 높았어서 좀 낮췄고, Jenkins에서도 램 좀 적당히 먹게 설정 수정했고,
Docker 이미지랑 컨테이너 정리는 새벽 3시에 크론잡으로 돌리는거로 변경했습니다. (I/O 최소화)

NCP가 스레기인 것도 있지만..  아마 CI 돌릴때 아주 쵸금 느려질거 같슴당


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 빌드 명령의 JVM 메모리 옵션을 간소화해 메모리 사용량을 줄이고 안정성을 개선했습니다.
  - Docker 정리(프룬) 단계를 비활성화해 예기치 않은 캐시 삭제를 방지했습니다.
  - CI 서비스 컨테이너에 자원 제한(최대 2 vCPU, 메모리 3GB)과 예약(메모리 1GB)을 설정해 실행 안정성과 자원 예측 가능성을 높였습니다.

- **New Features**
  - PR→dev 대상의 CI 테스트 단계와 주요 브랜치용 테스트 단계를 추가해 테스트 범위·결과(junit) 노출을 확대했습니다.
  - 메인 브랜치 판별 로직을 일관화해 빌드·푸시·배포 행동을 명확히 분기 처리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->